### PR TITLE
Enhance placeholder text for empty notebooks

### DIFF
--- a/packages/app-desktop/gui/NoteList/style.scss
+++ b/packages/app-desktop/gui/NoteList/style.scss
@@ -20,7 +20,7 @@
 			text-align: center; /* Center the text */
 			border: 1px dashed #ccc; /* Add a border for better visibility */
 			margin-top: 20px; 
-			border-radius: 8px; 
+			border-radius: 8px;
 	}
 }
 


### PR DESCRIPTION
Changes made:
- Updated the placeholder text in the `getEmptyFolderMessage` function.
- Modified the `.emptylist` CSS class to increase font size, change text color, and center the text.

![enhanceplaceholder](https://github.com/jiya-singhal/joplin/assets/155576892/53818cea-842e-4cdb-af2f-19a375b15259)
